### PR TITLE
release: bump playwright minor version to 0.2.0

### DIFF
--- a/src/playwright/devcontainer-feature.json
+++ b/src/playwright/devcontainer-feature.json
@@ -1,17 +1,17 @@
 {
-  "id": "playwright",
-  "version": "0.1.1",
-  "name": "Playwright",
-  "description": "Playwright enables reliable end-to-end testing for modern web apps.",
-  "dependsOn": {
-    "ghcr.io/devcontainers/features/common-utils:2": {},
-    "ghcr.io/devcontainers/features/node:1": {}
-  },
-  "options": {
-    "browsers": {
-      "type": "string",
-      "description": "A SPACE-separated list of browsers to install",
-      "default": ""
+    "id": "playwright",
+    "version": "0.2.0",
+    "name": "Playwright",
+    "description": "Playwright enables reliable end-to-end testing for modern web apps.",
+    "dependsOn": {
+        "ghcr.io/devcontainers/features/common-utils:2": {},
+        "ghcr.io/devcontainers/features/node:1": {}
+    },
+    "options": {
+        "browsers": {
+            "type": "string",
+            "description": "A SPACE-separated list of browsers to install",
+            "default": ""
+        }
     }
-  }
 }


### PR DESCRIPTION
This pull request updates the version of the Playwright devcontainer feature to ensure the environment uses the latest available configuration.

* Versioning update:
  * Increased the version of the Playwright devcontainer feature from `0.1.1` to `0.2.0` in `src/playwright/devcontainer-feature.json`