### PR TITLE
fix: source nvm in playwright install script so npx is on PATH

### DIFF
--- a/src/playwright/install.sh
+++ b/src/playwright/install.sh
@@ -2,11 +2,16 @@
 
 set -e
 
+# Source nvm so npx is available during feature installation
+# (containerEnv PATH additions from the node feature don't apply to install scripts)
+export NVM_DIR="${NVM_DIR:-/usr/local/share/nvm}"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
 # Install Playwright browsers
 # If _REMOTE_USER is set and not root, install as that user
 # Otherwise install as root (test scenarios)
 if [ -n "${_REMOTE_USER}" ] && [ "${_REMOTE_USER}" != "root" ] && id -u "${_REMOTE_USER}" > /dev/null 2>&1; then
-    su "${_REMOTE_USER}" -c "npx playwright install --with-deps ${BROWSERS}"
+    su "${_REMOTE_USER}" -c "export NVM_DIR=\"${NVM_DIR}\"; [ -s \"\$NVM_DIR/nvm.sh\" ] && . \"\$NVM_DIR/nvm.sh\"; npx playwright install --with-deps ${BROWSERS}"
 else
     npx playwright install --with-deps ${BROWSERS}
 fi


### PR DESCRIPTION
## Problem

When the `playwright` feature runs its `install.sh` during container build, `npx` is not found even when the `node` feature is listed as a dependency.

**Root cause:** The `node` feature adds `/usr/local/share/nvm/current/bin` to `PATH` via `containerEnv`. However, `containerEnv` is applied to the *running container*, not to feature install scripts during image build. So `npx` is never on `PATH` when playwright's install script executes.

This affects users who add the playwright feature alongside an explicit node feature, or rely on the `dependsOn: node` declared in `devcontainer-feature.json` — the install order is correct, but the PATH is still missing.

## Fix

Source `nvm.sh` at the top of `install.sh` before calling `npx`. The `su` invocation (for non-root installs) also re-sources nvm since it starts a fresh shell environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)